### PR TITLE
CI: add Node 20 to version matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
         deno-version: [1.19.x]
 
     steps:


### PR DESCRIPTION
20 is the "current" version of Node available.